### PR TITLE
Fix bugs in ipv6 PBR

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2959,7 +2959,7 @@ static_delete_ipv6 (struct prefix *p, struct in6_addr *gate,
   return 1;
 }
 #endif /* HAVE_IPV6 */
-
+
 /* RIB update function. */
 static void rib_update_table (struct route_table *table)
 {
@@ -2979,13 +2979,13 @@ rib_update (void)
 
   for (table = 0; table < 256; table++) {
     rib_update_table (vrf_table (AFI_IP, SAFI_UNICAST, table));
+#ifdef HAVE_IPV6
+    rib_update_table (vrf_table (AFI_IP6, SAFI_UNICAST, table));
+#endif
   }
 
-#ifdef HAVE_IPV6
-  rib_update_table (vrf_table (AFI_IP6, SAFI_UNICAST, 0));
-#endif
 }
-
+
 /* Remove all routes which comes from non main table.  */
 static void
 rib_weed_table (struct route_table *table)


### PR DESCRIPTION
Two bug fixes regarding IPv6 PBR (commit : https://github.com/vyos/vyatta-quagga/commit/8fad8bae1fecf0725f5e931d5f3337ccb9d5ec88)

First, in vtysh, "show running-configuration" would not print ipv6 routes in non default tables.

Secondly, ipv6 routes in a non default tables were not being updated when interfaces changed status. For instance, when using ppp interface, zebra would mark the routes as "inactive" while the interface appears down. When the interface comes up, zebra calls rib_update() to mark routes as active. Before this patch, only the main ipv6 routing table was updated by rib_update(). Every table is now.

This should close #168.
